### PR TITLE
chore: D-n 규칙에 따라 자동으로 Label 을 업데이트하는 Github Actions

### DIFF
--- a/.github/workflow/d-day-labeler.yml
+++ b/.github/workflow/d-day-labeler.yml
@@ -1,0 +1,12 @@
+name: Update D-n Labels
+on:
+  schedule:
+    - cron: '0 15 * * *' # 매일 밤 12시에 실행 (KST 기준)
+jobs:
+  d-day-labeler:
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Update D-n Labels
+        uses: naver/d-day-labeler@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Overview

## D-n 룰이란?
코드 리뷰가 완료되어야 하는 시점을 D-n 형식의 Label 을 PR 에 추가해 표현하는 방식입니다. 이를 통해 리뷰어는 리뷰 우선순위를 쉽게 판단하고 효율적으로 작업할 수 있습니다.

- 3일 이내에 리뷰가 완료되어야 한다면 PR 에 D-3 Label 을 추가합니다.
- 긴급한 수정 사항이 발생한다면 D-0 Label 을 사용하여 빠르게 리뷰를 수행하도록 합니다.

이 Label 은 매일 갱신되어야 합니다. 이를 자동화하기 위해 해당 Github Action을 사용합니다.

Closes #16 
