### PR TITLE
chore: develop to main

### DIFF
--- a/.github/workflows/d-day-labeler.yml
+++ b/.github/workflows/d-day-labeler.yml
@@ -2,6 +2,11 @@ name: Update D-n Labels
 on:
   schedule:
     - cron: '0 15 * * *' # 매일 밤 12시에 실행 (KST 기준)
+
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   d-day-labeler:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
# Overview

chore: develop to main
- [fix: d-day-labeler action (](https://github.com/allwagelab/client/commit/9f8d87f77e38651861c27eed7c0acb3887d491be)https://github.com/allwagelab/client/pull/25[)](https://github.com/allwagelab/client/commit/9f8d87f77e38651861c27eed7c0acb3887d491be)